### PR TITLE
`index` parameter of `CSSStyleSheet.insertRule` is now optional

### DIFF
--- a/.changeset/tricky-buttons-clap.md
+++ b/.changeset/tricky-buttons-clap.md
@@ -1,0 +1,5 @@
+---
+"rrweb-cssom": patch
+---
+
+`index` parameter of `CSSStyleSheet.insertRule` is now optional

--- a/lib/CSSStyleSheet.js
+++ b/lib/CSSStyleSheet.js
@@ -32,11 +32,14 @@ CSSOM.CSSStyleSheet.prototype.constructor = CSSOM.CSSStyleSheet;
  *   -> "img{border:none;}body{margin:0;}"
  *
  * @param {string} rule
- * @param {number} index
+ * @param {number} [index=0]
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-insertRule
  * @return {number} The index within the style sheet's rule collection of the newly inserted rule.
  */
 CSSOM.CSSStyleSheet.prototype.insertRule = function(rule, index) {
+	if (index === void 0) {
+		index = 0;
+	}
 	if (index < 0 || index > this.cssRules.length) {
 		throw new RangeError("INDEX_SIZE_ERR");
 	}

--- a/spec/CSSStyleSheet.spec.js
+++ b/spec/CSSStyleSheet.spec.js
@@ -24,6 +24,15 @@ describe('CSSStyleSheet', function() {
 			s.insertRule("a {color: blue}", 0);
 			expect(s.cssRules[0].parentStyleSheet).toBe(s);
 		});
+
+		it('should insert in index 0 by default', function () {
+			var s = new CSSOM.CSSStyleSheet;
+			s.insertRule("a {color: blue}", 0);
+
+			var insertedIndex = s.insertRule("b {color: black;}");
+			expect(insertedIndex).toEqual(0);
+			expect(s.cssRules[0].cssText).toEqual("b {color: black;}");
+		})
 	});
 });
 });


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule#index

> index (Optional)
> 
> A positive integer less than or equal to stylesheet.cssRules.length, representing the newly inserted rule's position in [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).cssRules. The default is 0.