### PR TITLE
fix: handle null parentRule when parsing @media after nested selectors in @layer

### DIFF
--- a/.changeset/petite-aliens-jam.md
+++ b/.changeset/petite-aliens-jam.md
@@ -1,0 +1,7 @@
+---
+"@acemir/cssom": patch
+---
+
+Fix TypeError when parsing @media after nested selectors inside @layer
+
+When parsing CSS with nested selectors (&) followed by @media rules inside an @layer block, the parser would crash with "Cannot read properties of null (reading 'constructor')" because nestedSelectorRule.parentRule can be null when the parent context is a CSSLayerBlockRule rather than a CSSStyleRule.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1443,7 +1443,7 @@ CSSOM.parse = function parse(token, opts, errorHandler) {
 				if (styleRule && styleRule.constructor.name === "CSSNestedDeclarations") {
 					currentScope.cssRules.push(styleRule);
 				}
-				if (nestedSelectorRule.parentRule.constructor.name === "CSSStyleRule") {
+				if (nestedSelectorRule.parentRule && nestedSelectorRule.parentRule.constructor.name === "CSSStyleRule") {
 					styleRule = nestedSelectorRule.parentRule;
 				}
 				nestedSelectorRule = null;

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -2768,6 +2768,70 @@ var CSS_NESTING_TESTS = [
 			return result;
 		})()
 	},
+	{
+		// BUG: CSS nesting with & selector followed by @media inside @layer throws TypeError
+		// "Cannot read properties of null (reading 'constructor')" at parse.js:1446
+		// The order matters: & nesting BEFORE @media fails, but @media BEFORE & nesting works
+		input: "@layer components { .A { &:hover { color: red; } } @media (min-width: 0) { .B { color: blue; } } }",
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						name: "components",
+						cssRules: [
+							{
+								selectorText: ".A",
+								style: {
+									length: 0
+								},
+								cssRules: [
+									{
+										cssRules: [],
+										selectorText: "&:hover",
+										style: {
+											0: "color",
+											color: "red",
+											length: 1
+										},
+									}
+								],
+							},
+							{
+								conditionText: "(min-width: 0)",
+								media: {
+									0: "(min-width: 0)",
+									length: 1
+								},
+								cssRules: [
+									{
+										cssRules: [],
+										selectorText: ".B",
+										style: {
+											0: "color",
+											color: "blue",
+											length: 1
+										},
+									}
+								],
+							}
+						],
+						parentRule: null,
+					}
+				],
+				parentStyleSheet: null
+			};
+			result.cssRules[0].parentStyleSheet = result.cssRules[0].cssRules[0].parentStyleSheet = result.cssRules[0].cssRules[1].parentStyleSheet = result;
+			result.cssRules[0].cssRules[0].parentRule = result.cssRules[0].cssRules[1].parentRule = result.cssRules[0];
+			result.cssRules[0].cssRules[0].style.parentRule = result.cssRules[0].cssRules[0];
+			result.cssRules[0].cssRules[0].cssRules[0].parentStyleSheet = result;
+			result.cssRules[0].cssRules[0].cssRules[0].parentRule = result.cssRules[0].cssRules[0];
+			result.cssRules[0].cssRules[0].cssRules[0].style.parentRule = result.cssRules[0].cssRules[0].cssRules[0];
+			result.cssRules[0].cssRules[1].cssRules[0].parentStyleSheet = result;
+			result.cssRules[0].cssRules[1].cssRules[0].parentRule = result.cssRules[0].cssRules[1];
+			result.cssRules[0].cssRules[1].cssRules[0].style.parentRule = result.cssRules[0].cssRules[1].cssRules[0];
+			return result;
+		})()
+	},
 ];
 
 var VALIDATION_TESTS = [


### PR DESCRIPTION
When parsing CSS with nested selectors (`&`) followed by `@media` rules inside an `@layer` block, the parser would crash with:
> "Cannot read properties of null (reading 'constructor')" 

This is because `nestedSelectorRule.parentRule` can be null when the parent context is a `CSSLayerBlockRule` rather than a `CSSStyleRule`.

Added test to reproduce, then added a null check before accessing `parentRule.constructor.name`. All tests pass after fix. Also added a changeset.