### PR TITLE
Add CSSStyleDeclaration injection API for parsed rule styles

### DIFF
--- a/.changeset/late-wolves-tickle.md
+++ b/.changeset/late-wolves-tickle.md
@@ -1,0 +1,13 @@
+---
+"@acemir/cssom": minor
+---
+
+Add an explicit CSSStyleDeclaration integration API.
+
+New APIs:
+- `setup({ CSSStyleDeclaration })`
+- `setCSSStyleDeclaration(CSSStyleDeclaration)`
+- `getCSSStyleDeclaration()`
+- `resetCSSStyleDeclaration()`
+
+Rule style declarations created during parsing/cloning now use the configured constructor consistently, avoiding module load-order issues when integrating with custom CSSStyleDeclaration implementations.

--- a/README.mdown
+++ b/README.mdown
@@ -33,6 +33,19 @@ To use it with Node.js or any other CommonJS loader:
 
     ➤ npm install @acemir/cssom
 
+You can inject a custom declaration implementation for parsed rule styles:
+
+```js
+const cssom = require("@acemir/cssom");
+
+cssom.setup({
+  CSSStyleDeclaration: YourCSSStyleDeclaration
+});
+
+// or globally:
+cssom.setCSSStyleDeclaration(YourCSSStyleDeclaration);
+```
+
 ## Don’t use it if...
 
 You parse CSS to mungle, minify or reformat code like this:

--- a/lib/CSSFontFaceRule.js
+++ b/lib/CSSFontFaceRule.js
@@ -1,14 +1,13 @@
 //.CommonJS
 var CSSOM = {
-	CSSStyleDeclaration: require("./CSSStyleDeclaration").CSSStyleDeclaration,
 	CSSRule: require("./CSSRule").CSSRule
 };
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+var styleDeclarationProvider = require("./styleDeclarationProvider");
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+	enumerable: true,
+	configurable: true,
+	get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/CSSKeyframeRule.js
+++ b/lib/CSSKeyframeRule.js
@@ -1,14 +1,13 @@
 //.CommonJS
 var CSSOM = {
-	CSSRule: require("./CSSRule").CSSRule,
-	CSSStyleDeclaration: require('./CSSStyleDeclaration').CSSStyleDeclaration
+	CSSRule: require("./CSSRule").CSSRule
 };
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+var styleDeclarationProvider = require("./styleDeclarationProvider");
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+	enumerable: true,
+	configurable: true,
+	get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/CSSNestedDeclarations.js
+++ b/lib/CSSNestedDeclarations.js
@@ -1,14 +1,13 @@
 //.CommonJS
 var CSSOM = {
-  CSSRule: require("./CSSRule").CSSRule,
-  CSSStyleDeclaration: require('./CSSStyleDeclaration').CSSStyleDeclaration
+  CSSRule: require("./CSSRule").CSSRule
 };
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+var styleDeclarationProvider = require("./styleDeclarationProvider");
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+  enumerable: true,
+  configurable: true,
+  get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/CSSOM.js
+++ b/lib/CSSOM.js
@@ -4,6 +4,7 @@ var CSSOM = {
    * 
    * @param {Object} opts - Configuration options for the CSSOM instance
    * @param {Object} [opts.globalObject] - Optional global object to be assigned to CSSOM objects prototype
+   * @param {Function} [opts.CSSStyleDeclaration] - Optional constructor used for declaration blocks in parsed rules
    * @returns {Object} A new CSSOM instance with the applied configuration
    * @description
    * This method creates a new instance of CSSOM and optionally
@@ -12,7 +13,13 @@ var CSSOM = {
    * using a factory function and assigns the globalObject to its prototype's __globalObject property.
    */
   setup: function (opts) {
+    opts = opts || {};
     var instance = Object.create(this);
+    if (opts.CSSStyleDeclaration) {
+      var styleDeclarationProvider = require("./styleDeclarationProvider");
+      styleDeclarationProvider.setCSSStyleDeclaration(opts.CSSStyleDeclaration);
+      instance.CSSStyleDeclaration = opts.CSSStyleDeclaration;
+    }
     if (opts.globalObject) {
       if (instance.CSSStyleSheet) {
         var factoryCSSStyleSheet = createFunctionFactory(instance.CSSStyleSheet);
@@ -55,4 +62,3 @@ function createFunctionFactory(fn) {
 //.CommonJS
 module.exports = CSSOM;
 ///CommonJS
-

--- a/lib/CSSPageRule.js
+++ b/lib/CSSPageRule.js
@@ -1,17 +1,16 @@
 //.CommonJS
 var CSSOM = {
-	CSSStyleDeclaration: require("./CSSStyleDeclaration").CSSStyleDeclaration,
 	CSSRule: require("./CSSRule").CSSRule,
 	CSSRuleList: require("./CSSRuleList").CSSRuleList,
 	CSSGroupingRule: require("./CSSGroupingRule").CSSGroupingRule,
 };
+var styleDeclarationProvider = require("./styleDeclarationProvider");
 var regexPatterns = require("./regexPatterns").regexPatterns;
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+	enumerable: true,
+	configurable: true,
+	get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/CSSStyleRule.js
+++ b/lib/CSSStyleRule.js
@@ -1,17 +1,16 @@
 //.CommonJS
 var CSSOM = {
-	CSSStyleDeclaration: require("./CSSStyleDeclaration").CSSStyleDeclaration,
 	CSSRule: require("./CSSRule").CSSRule,
 	CSSRuleList: require("./CSSRuleList").CSSRuleList,
 	CSSGroupingRule: require("./CSSGroupingRule").CSSGroupingRule,
 };
+var styleDeclarationProvider = require("./styleDeclarationProvider");
 var regexPatterns = require("./regexPatterns").regexPatterns;
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+	enumerable: true,
+	configurable: true,
+	get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -9,19 +9,18 @@ var CSSOM = {
 	CSSMediaRule: require("./CSSMediaRule").CSSMediaRule,
 	CSSContainerRule: require("./CSSContainerRule").CSSContainerRule,
 	CSSSupportsRule: require("./CSSSupportsRule").CSSSupportsRule,
-	CSSStyleDeclaration: require("./CSSStyleDeclaration").CSSStyleDeclaration,
 	CSSKeyframeRule: require('./CSSKeyframeRule').CSSKeyframeRule,
 	CSSKeyframesRule: require('./CSSKeyframesRule').CSSKeyframesRule,
 	CSSScopeRule: require('./CSSScopeRule').CSSScopeRule,
 	CSSLayerBlockRule: require('./CSSLayerBlockRule').CSSLayerBlockRule,
 	CSSLayerStatementRule: require('./CSSLayerStatementRule').CSSLayerStatementRule
 };
-// Use cssstyle if available
-try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
-} catch (e) {
-	// ignore
-}
+var styleDeclarationProvider = require("./styleDeclarationProvider");
+Object.defineProperty(CSSOM, "CSSStyleDeclaration", {
+	enumerable: true,
+	configurable: true,
+	get: styleDeclarationProvider.getCSSStyleDeclaration
+});
 ///CommonJS
 
 

--- a/lib/cssstyleTryCatchBlock.js
+++ b/lib/cssstyleTryCatchBlock.js
@@ -1,5 +1,9 @@
+//.CommonJS
+var styleDeclarationProvider = require("./styleDeclarationProvider");
+
 try {
-	CSSOM.CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
+	styleDeclarationProvider.setCSSStyleDeclaration(require("cssstyle").CSSStyleDeclaration);
 } catch (e) {
 	// ignore
 }
+///CommonJS

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,15 @@ require('./errorUtils');
 require("./regexPatterns")
 
 exports.CSSStyleDeclaration = require('./CSSStyleDeclaration').CSSStyleDeclaration;
+exports.getCSSStyleDeclaration = function() {
+	return require("./styleDeclarationProvider").getCSSStyleDeclaration();
+};
+exports.setCSSStyleDeclaration = function(CSSStyleDeclaration) {
+	return require("./styleDeclarationProvider").setCSSStyleDeclaration(CSSStyleDeclaration);
+};
+exports.resetCSSStyleDeclaration = function() {
+	return require("./styleDeclarationProvider").resetCSSStyleDeclaration();
+};
 
 require('./cssstyleTryCatchBlock');
 

--- a/lib/styleDeclarationProvider.js
+++ b/lib/styleDeclarationProvider.js
@@ -1,0 +1,28 @@
+//.CommonJS
+var currentCSSStyleDeclaration;
+///CommonJS
+
+function getDefaultCSSStyleDeclaration() {
+	return require("./CSSStyleDeclaration").CSSStyleDeclaration;
+}
+
+function getCSSStyleDeclaration() {
+	return currentCSSStyleDeclaration || getDefaultCSSStyleDeclaration();
+}
+
+function setCSSStyleDeclaration(CSSStyleDeclaration) {
+	if (typeof CSSStyleDeclaration !== "function") {
+		throw new TypeError("CSSStyleDeclaration must be a constructor function");
+	}
+	currentCSSStyleDeclaration = CSSStyleDeclaration;
+}
+
+function resetCSSStyleDeclaration() {
+	currentCSSStyleDeclaration = undefined;
+}
+
+//.CommonJS
+exports.getCSSStyleDeclaration = getCSSStyleDeclaration;
+exports.setCSSStyleDeclaration = setCSSStyleDeclaration;
+exports.resetCSSStyleDeclaration = resetCSSStyleDeclaration;
+///CommonJS


### PR DESCRIPTION
## Summary
- add a `styleDeclarationProvider` abstraction to resolve the declaration constructor used when creating rule `style` objects
- add public APIs in `lib/index.js`:
  - `getCSSStyleDeclaration()`
  - `setCSSStyleDeclaration(CSSStyleDeclaration)`
  - `resetCSSStyleDeclaration()`
- extend `setup()` to accept `CSSStyleDeclaration` and wire it via provider
- switch rule/clone construction sites to use the provider-backed constructor dynamically (avoids module load-order capture)
- keep existing optional `cssstyle` fallback behavior by routing it through the same provider
- document usage in `README.mdown`

## Why
Consumers like jsdom need to inject their own `CSSStyleDeclaration` implementation. Reassigning `require("@acemir/cssom/lib/CSSStyleDeclaration").CSSStyleDeclaration` is not reliable because multiple modules capture constructor references during module initialization.

This PR provides an explicit integration point so parser-created rule declarations are consistently constructed with the consumer-provided class.

## Validation
- `npm run build`
- runtime smoke checks from Node confirming:
  - default path still works
  - `setup({ CSSStyleDeclaration })` causes parsed rule styles to use the injected constructor
